### PR TITLE
Added BadgeWX Support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 build/
+nbproject/
 release/release
 release/patch
 *.zip
 *.bin
 *.elf
+*.ld
+*.bak
 *~
 test-framework-*

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ VERSION=$(GIT_VERSION) ($(shell date "+%Y-%m-%d %H:%M:%S")$(GIT_COMMIT_HASH_SUFF
 $(info VERSION $(VERSION))
 
 #SPI flash size, in K
-ESP_SPI_FLASH_SIZE_K=4096
+ESP_SPI_FLASH_SIZE_K=2048
 #Amount of the flash to use for the image(s)
 ESP_SPI_IMAGE_SIZE_K=1024
 #0: QIO, 1: QOUT, 2: DIO, 3: DOUT

--- a/parallax/httpdroffs.c
+++ b/parallax/httpdroffs.c
@@ -109,7 +109,7 @@ cgiRoffsHook(HttpdConnData *connData) {
 
 int ICACHE_FLASH_ATTR cgiRoffsFormat(HttpdConnData *connData)
 {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -133,7 +133,7 @@ int ICACHE_FLASH_ATTR cgiRoffsWriteFile(HttpdConnData *connData)
 {
     ROFFS_FILE *file = connData->cgiData;
     
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;

--- a/parallax/sscp-cmds.c
+++ b/parallax/sscp-cmds.c
@@ -21,7 +21,15 @@ void ICACHE_FLASH_ATTR cmds_do_nothing(int argc, char *argv[])
 // JOIN,ssid,passwd
 void ICACHE_FLASH_ATTR cmds_do_join(int argc, char *argv[])
 {
-    if (argc != 3) {
+    if (argc == 1) {
+        
+        // Auto Join!
+        wifiJoinAuto();
+        sscp_sendResponse("S,0");
+        return;
+    }
+    
+    else if (argc != 3) {
         sscp_sendResponse("E,%d", SSCP_ERROR_WRONG_ARGUMENT_COUNT);
         return;
     }
@@ -29,7 +37,7 @@ void ICACHE_FLASH_ATTR cmds_do_join(int argc, char *argv[])
     if (wifiJoin(argv[1], argv[2]) == 0)
         sscp_sendResponse("S,0");
     else
-        sscp_sendResponse("E,%d", SSCP_ERROR_INVALID_ARGUMENT);
+        sscp_sendResponse("E,%d", SSCP_ERROR_INVALID_ARGUMENT); // mm: This can never be called ???!! wifiJoin can only return 0 as currently coded
 }
 
 static void ICACHE_FLASH_ATTR path_handler(sscp_hdr *hdr)
@@ -159,6 +167,35 @@ void ICACHE_FLASH_ATTR cmds_do_close(int argc, char *argv[])
     hdr->type = TYPE_UNUSED;
         
     sscp_sendResponse("S,0");
+}
+
+// RESTART,hard
+void ICACHE_FLASH_ATTR cmds_do_restart(int argc, char *argv[])
+{
+    if (argc != 2) {
+        sscp_sendResponse("E,%d", SSCP_ERROR_WRONG_ARGUMENT_COUNT);
+        return;
+    }
+    
+    if (atoi(argv[1]) == 0) {
+        sscp_log("RESTART 0 : system_restart");
+        //ESP.restart();
+        system_restart();
+        sscp_sendResponse("S,0");
+        return;
+    
+    } else if (atoi(argv[1]) == 1) {
+        sscp_log("RESTART 1 : system_upgrade_reboot");
+        //ESP.reset();
+        system_upgrade_reboot();
+        sscp_sendResponse("S,0");
+        return;
+    
+    } else {
+        
+        sscp_sendResponse("E,%d", SSCP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
 }
 
 // SEND,chan,count

--- a/parallax/sscp-settings.c
+++ b/parallax/sscp-settings.c
@@ -445,7 +445,7 @@ int ICACHE_FLASH_ATTR cgiPropSetting(HttpdConnData *connData)
     cmd_def *def = NULL;
     int i;
     
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (connData->requestType == HTTPD_METHOD_POST && IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -514,7 +514,7 @@ int ICACHE_FLASH_ATTR cgiPropSetting(HttpdConnData *connData)
 
 int ICACHE_FLASH_ATTR cgiPropSaveSettings(HttpdConnData *connData)
 {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -528,7 +528,7 @@ int ICACHE_FLASH_ATTR cgiPropSaveSettings(HttpdConnData *connData)
 
 int ICACHE_FLASH_ATTR cgiPropRestoreSettings(HttpdConnData *connData)
 {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -542,7 +542,7 @@ int ICACHE_FLASH_ATTR cgiPropRestoreSettings(HttpdConnData *connData)
 
 int ICACHE_FLASH_ATTR cgiPropRestoreDefaultSettings(HttpdConnData *connData)
 {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;

--- a/parallax/sscp.c
+++ b/parallax/sscp.c
@@ -316,11 +316,13 @@ static cmd_def cmds[] = {
 {   "SEND",             cmds_do_send        },
 {   "RECV",             cmds_do_recv        },
 {   "CLOSE",            cmds_do_close       },
+{   "RESTART",          cmds_do_restart     },
 {   "ARG",              http_do_arg         },
 {   "REPLY",            http_do_reply       },
 {   "CONNECT",          tcp_do_connect      },
 {   "APSCAN",           wifi_do_apscan      },
 {   "APGET",            wifi_do_apget       },
+{   "APSET",            wifi_do_apset       },
 {   "FINFO",            fs_do_finfo         },
 {   "FCOUNT",           fs_do_fcount        },
 {   "FRUN",             fs_do_frun          },
@@ -472,12 +474,14 @@ void ICACHE_FLASH_ATTR sscp_filter(char *buf, short len, void (*outOfBand)(void 
             case SSCP_TKN_SEND:
             case SSCP_TKN_RECV:
             case SSCP_TKN_CLOSE:
+            case SSCP_TKN_RESTART:
             case SSCP_TKN_LISTEN:
             case SSCP_TKN_ARG:
             case SSCP_TKN_REPLY:
             case SSCP_TKN_CONNECT:
             case SSCP_TKN_APSCAN:
             case SSCP_TKN_APGET:
+            case SSCP_TKN_APSET:
             case SSCP_TKN_HTTP:
             case SSCP_TKN_WS:
             case SSCP_TKN_TCP:
@@ -496,12 +500,14 @@ void ICACHE_FLASH_ATTR sscp_filter(char *buf, short len, void (*outOfBand)(void 
                     case SSCP_TKN_SEND:     name = "SEND";    sep = ':'; break;
                     case SSCP_TKN_RECV:     name = "RECV";    sep = ':'; break;
                     case SSCP_TKN_CLOSE:    name = "CLOSE";   sep = ':'; break;
+                    case SSCP_TKN_RESTART:  name = "RESTART"; sep = ':'; break;
                     case SSCP_TKN_LISTEN:   name = "LISTEN";  sep = ':'; break;
                     case SSCP_TKN_ARG:      name = "ARG";     sep = ':'; break;
                     case SSCP_TKN_REPLY:    name = "REPLY";   sep = ':'; break;
                     case SSCP_TKN_CONNECT:  name = "CONNECT"; sep = ':'; break;
                     case SSCP_TKN_APSCAN:   name = "APSCAN";  sep = ':'; break;
                     case SSCP_TKN_APGET:    name = "APGET";   sep = ':'; break;
+                    case SSCP_TKN_APSET:    name = "APSET";   sep = ':'; break;
                     case SSCP_TKN_FINFO:    name = "FINFO";   sep = ':'; break;
                     case SSCP_TKN_FCOUNT:   name = "FCOUNT";  sep = ':'; break;
                     case SSCP_TKN_FRUN:     name = "FRUN";    sep = ':'; break;

--- a/parallax/sscp.h
+++ b/parallax/sscp.h
@@ -37,8 +37,8 @@ enum {
     SSCP_TKN_STA                = 0xF4,
     SSCP_TKN_AP                 = 0xF3,
     SSCP_TKN_STA_AP             = 0xF2,
-    
-    // gap for more tokens
+    SSCP_TKN_APSET              = 0xF1,
+    SSCP_TKN_RESTART            = 0xF0,
     
     SSCP_TKN_JOIN               = 0xEF,
     SSCP_TKN_CHECK              = 0xEE,
@@ -189,6 +189,7 @@ void cmds_do_path(int argc, char *argv[]);
 void cmds_do_send(int argc, char *argv[]);
 void cmds_do_recv(int argc, char *argv[]);
 void cmds_do_close(int argc, char *argv[]);
+void cmds_do_restart(int argc, char *argv[]);
 int cgiPropEnableSerialProtocol(HttpdConnData *connData);
 int cgiPropModuleInfo(HttpdConnData *connData);
 
@@ -217,6 +218,7 @@ void tcp_do_connect(int argc, char *argv[]);
 // from sscp-wifi.c
 void wifi_do_apscan(int argc, char *argv[]);
 void wifi_do_apget(int argc, char *argv[]);
+void wifi_do_apset(int argc, char *argv[]);
 int wifi_check_for_events(void);
 
 // from sscp-fs.c

--- a/parallax/user_main.c
+++ b/parallax/user_main.c
@@ -131,7 +131,7 @@ CgiUploadFlashDef uploadParams={
 #endif
 
 static int ICACHE_FLASH_ATTR cgiGetFirmwareNextFilter(HttpdConnData *connData) {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (connData->conn != NULL && IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -141,7 +141,7 @@ static int ICACHE_FLASH_ATTR cgiGetFirmwareNextFilter(HttpdConnData *connData) {
 }
 
 int ICACHE_FLASH_ATTR cgiUploadFirmwareFilter(HttpdConnData *connData) {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (connData->conn != NULL && IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -151,7 +151,7 @@ int ICACHE_FLASH_ATTR cgiUploadFirmwareFilter(HttpdConnData *connData) {
 }
 
 int ICACHE_FLASH_ATTR cgiWiFiConnectFilter(HttpdConnData *connData) {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (connData->conn != NULL && IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -161,7 +161,7 @@ int ICACHE_FLASH_ATTR cgiWiFiConnectFilter(HttpdConnData *connData) {
 }
 
 int ICACHE_FLASH_ATTR cgiWiFiSetModeFilter(HttpdConnData *connData) {
-#ifdef WIFI_BADGE
+#ifdef AUTO_LOAD
     if (connData->conn != NULL && IsAutoLoadEnabled()) {
         httpdSendResponse(connData, 400, "Not allowed\r\n", -1);
         return HTTPD_CGI_DONE;
@@ -240,8 +240,11 @@ static void ICACHE_FLASH_ATTR prHeapTimerCb(void *arg) {
 //Main routine. Initialize stdout, the I/O, filesystem and the webserver and we're done.
 void ICACHE_FLASH_ATTR user_init(void) {
     int restoreOk;
+    
+    //wifi_station_set_auto_connect(TRUE); // Default on; may be overwritten by valid flash config
 
     if (!(restoreOk = configRestore()))
+        //wifi_station_set_auto_connect(TRUE); // Default on; may be overwritten by valid flash config
         configSave();
 
     wifi_station_set_hostname(flashConfig.module_name);


### PR DESCRIPTION
michael@atomitech.hu
- Fixed bug in APSCAN command that always returned success regardless of the outcome.
- Fixed inconsistency in APGET command where it responded with a variable-length string as the second-to-last field; inconsistent with rest of API.
- Enhanced AutoLoad feature to delay a relock event for 5 seconds to prevent locking out the current programming process.
- Enhanced JOIN command to automatically join if no arguments provided.
- Added RESTART command to restart ESP or reboot for upgrading.
- Added APSET command to configure Wi-Fi credentials through command interface.
- Set to make as 2M image instead of 4M in preparation for possibility of modules changing to 2M size unexpectedly.

jmartin@parallax.com
- Changed WIFI_BADGE compile directive to AUTO_LOAD.
- Updated to ignore nbproject/ folder and *.ld and *.bak files.